### PR TITLE
Fix translations and streamline format

### DIFF
--- a/content/_index.ca.md
+++ b/content/_index.ca.md
@@ -1,15 +1,15 @@
 # gooby.cat
 
-![Photo of my two gooby cats](/goobycats.jpg)
+![Foto dels meus dos "gooby cats"](/goobycats.jpg)
 
-Benvinguts a gooby.cat! Sóc Shay i visc a prop de Berlin. Actualment treballo a [ViaEurope](https://github.com/viaeurope) i tinc una mica d'experiència a Ruby i Python. Prèviament he treballat amb Kubernetes i algunes coses a cloud.
+Benvinguts a gooby.cat! Sóc Shay i visc a prop de Berlin. Actualment treballo a [ViaEurope](https://github.com/viaeurope) i tinc una mica d'experiència amb Ruby i Python. Prèviament he treballat amb Kubernetes i algunes coses de cloud.
 
-Enjoy your stay :)
+_Enjoy your stay_ :)
 
-## Projectos
+## Projectes
 
-* **Animal of the Week:** Aplicació escrita a Ruby on Rails que t'ensenya el gat silly de la setmana! [Source code](https://github.com/9c23a5/animal-otw) // [Blog posts]()
+* **Animal of the Week:** Aplicació escrita amb Ruby on Rails que t'ensenya el gat _silly_ de la setmana! [Codi font](https://github.com/9c23a5/animal-otw) // [Entrades del blog]()
 
-* **Aquesta web:** Usant Hugo i el tema risotto. [Source code](https://github.com/9c23a5/gooby-cat) // [Blog posts]()
+* **Aquesta web:** Usant Hugo i el tema risotto. [Source code](https://github.com/9c23a5/gooby-cat) // [Entrades del blog]()
 
-* **Advent of Code:** Repositori per apuntar totes les meves respostes a AoC a Ruby. [Source code](https://github.com/9c23a5/advent-of-code) // [Blog posts]()
+* **Advent of Code:** Repositori per apuntar totes les meves respostes de l'AoC amb Ruby. [Codi font](https://github.com/9c23a5/advent-of-code) // [Entrades del blog]()


### PR DESCRIPTION
Includes #1

Fixes "projects" and it's translations, translates the image descriptions (a11y!) and streamlines italics